### PR TITLE
Fix Linux support on OBV

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -1,0 +1,406 @@
+import os
+import sys
+from ambuild.command import SymlinkCommand
+
+class Viper:
+	def __init__(self):
+		self.compiler = Cpp.Compiler()
+
+		# Build SDK info
+		self.sdkInfo = { }
+		self.sdkInfo['ep1'] = {
+			'sdk': 'HL2SDK',
+			'ext': '1.ep1',
+			'def': '1',
+			'name': 'EPISODEONE',
+			'platform': [
+				'windows', 'linux'
+			]
+		}
+		
+		self.sdkInfo['ep2'] = {
+			'sdk': 'HL2SDKOB',
+			'ext': '2.ep2',
+			'def': '3',
+			'name': 'ORANGEBOX',      
+			'platform': [
+				'windows', 'linux'
+			]
+		}
+		
+		self.sdkInfo['ep2v'] = {
+			'sdk': 'HL2SDKOBVALVE',
+			'ext': '2.ep2v',
+			'def': '5',
+			'name': 'ORANGEBOXVALVE',
+			'platform': [
+				'windows', 'linux', 'darwin'
+			]
+		}
+		
+		self.sdkInfo['l4d'] = {
+			'sdk': 'HL2SDKL4D',
+			'ext': '2.l4d',
+			'def': '6',
+			'name': 'LEFT4DEAD',
+			'platform': [
+				'windows', 'linux', 'darwin'
+			]
+		}
+		
+		self.sdkInfo['l4d2'] = {
+			'sdk': 'HL2SDKL4D2',
+			'ext': '2.l4d2',
+			'def': '7',
+			'name': 'LEFT4DEAD2',
+			'platform': [
+				'windows', 'linux', 'darwin'
+			]
+		}
+		
+		self.sdkInfo['darkm'] = {
+			'sdk': 'HL2SDK-DARKM',
+			'ext': '2.darkm',
+			'def': '2',
+			'name': 'DARKMESSIAH',
+			'platform': [
+				'windows'
+			]
+		}
+		
+		self.sdkInfo['swarm'] = {
+			'sdk': 'HL2SDK-SWARM',
+			'ext': '2.swarm',
+			'def': '8',
+			'name': 'ALIENSWARM',     
+			'platform': [
+				'windows'
+			]
+		}
+		
+		self.sdkInfo['bgt'] = {
+			'sdk': 'HL2SDK-BGT',
+			'ext': '2.bgt',
+			'def': '4',
+			'name': 'BLOODYGOODTIME',
+			'platform': [
+				'windows'
+			]
+		}
+
+		if AMBuild.mode == 'config':
+			# Detect compilers
+			self.compiler.DetectAll(AMBuild)
+
+			# Detect variables
+			envvars = { 'SOURCEMOD':     'sourcemod-central',
+						'MMSOURCE18':    'mmsource-central',
+						'HL2SDKOBVALVE': 'hl2sdk-ob-valve',
+						'HL2SDKL4D':     'hl2sdk-l4d',
+						'HL2SDKL4D2':    'hl2sdk-l4d2',
+						'PYTHONSOURCE':  'Python-2.5.4',
+			}
+
+			if AMBuild.target['platform'] != 'darwin':
+				envvars['HL2SDK'] = 'hl2sdk'
+				envvars['HL2SDKOB'] = 'hl2sdk-ob'
+
+			# Dark Messiah is Windows-only
+			if AMBuild.target['platform'] == 'windows':
+				envvars['HL2SDK-DARKM'] = 'hl2sdk-darkm'
+				envvars['HL2SDK-SWARM'] = 'hl2sdk-swarm'
+				envvars['HL2SDK-BGT']   = 'hl2sdk-bgt'
+
+			for i in envvars:
+				if i in os.environ:
+					path = os.environ[i]
+					if not os.path.isdir(path):
+						# raise Exception('Path for {0} was not found: {1}'.format(i, path))
+						continue
+				else:
+					head = os.getcwd()
+					oldhead = None
+					while head != None and head != oldhead:
+						path = os.path.join(head, envvars[i])
+						if os.path.isdir(path):
+							break
+						oldhead = head
+						head, tail = os.path.split(head)
+					if head == None or head == oldhead:
+						# raise Exception('Could not find a valid path for {0}'.format(i))
+						continue
+				AMBuild.cache.CacheVariable(i, path)
+
+			# Set up defines
+			cxx = self.compiler.cxx
+			if isinstance(cxx, Cpp.CompatGCC):
+				if isinstance(cxx, Cpp.GCC):
+					self.vendor = 'gcc'
+				elif isinstance(cxx, Cpp.Clang):
+					self.vendor = 'clang'
+				self.compiler.AddToListVar('CDEFINES', 'stricmp=strcasecmp')
+				self.compiler.AddToListVar('CDEFINES', '_stricmp=strcasecmp')
+				self.compiler.AddToListVar('CDEFINES', '_snprintf=snprintf')
+				self.compiler.AddToListVar('CDEFINES', '_vsnprintf=vsnprintf')
+				self.compiler.AddToListVar('CFLAGS', '-pipe')
+				self.compiler.AddToListVar('CFLAGS', '-fno-strict-aliasing')
+				if (self.vendor == 'gcc' and cxx.majorVersion >= 4) or self.vendor == 'clang':
+					self.compiler.AddToListVar('CFLAGS', '-fvisibility=hidden')
+					self.compiler.AddToListVar('CXXFLAGS', '-fvisibility-inlines-hidden')
+				self.compiler.AddToListVar('CFLAGS', '-Wall')
+				self.compiler.AddToListVar('CFLAGS', '-Wno-uninitialized')
+				self.compiler.AddToListVar('CFLAGS', '-Wno-unused')
+				self.compiler.AddToListVar('CFLAGS', '-Wno-switch')
+				self.compiler.AddToListVar('CFLAGS', '-msse')
+				self.compiler.AddToListVar('CFLAGS', '-m32')
+				self.compiler.AddToListVar('POSTLINKFLAGS', '-m32')
+				self.compiler.AddToListVar('CXXFLAGS', '-fno-exceptions')
+				self.compiler.AddToListVar('CXXFLAGS', '-fno-rtti')
+				self.compiler.AddToListVar('CXXFLAGS', '-fno-threadsafe-statics')
+				self.compiler.AddToListVar('CXXFLAGS', '-Wno-non-virtual-dtor')
+				self.compiler.AddToListVar('CXXFLAGS', '-Wno-overloaded-virtual')
+				self.compiler.AddToListVar('CDEFINES', 'HAVE_STDINT_H')
+				if self.vendor == 'gcc':
+					self.compiler.AddToListVar('CFLAGS', '-mfpmath=sse')
+					self.compiler.AddToListVar('POSTLINKFLAGS', '-static-libgcc')
+			elif isinstance(cxx, Cpp.MSVC):
+				self.vendor = 'msvc'
+				if AMBuild.options.debug == '1':
+					self.compiler.AddToListVar('CFLAGS', '/MTd')
+					self.compiler.AddToListVar('POSTLINKFLAGS', '/NODEFAULTLIB:libcmt')
+				else:
+					self.compiler.AddToListVar('CFLAGS', '/MT')
+				self.compiler.AddToListVar('CDEFINES', '_CRT_SECURE_NO_DEPRECATE')
+				self.compiler.AddToListVar('CDEFINES', '_CRT_SECURE_NO_WARNINGS')
+				self.compiler.AddToListVar('CDEFINES', '_CRT_NONSTDC_NO_DEPRECATE')
+				self.compiler.AddToListVar('CXXFLAGS', '/EHsc')
+				self.compiler.AddToListVar('CXXFLAGS', '/GR-')
+				self.compiler.AddToListVar('CFLAGS', '/W3')
+				self.compiler.AddToListVar('CFLAGS', '/nologo')
+				self.compiler.AddToListVar('CFLAGS', '/Zi')
+				self.compiler.AddToListVar('CXXFLAGS', '/TP')
+				self.compiler.AddToListVar('POSTLINKFLAGS', '/DEBUG')
+				self.compiler.AddToListVar('POSTLINKFLAGS', '/MACHINE:X86')
+				self.compiler.AddToListVar('POSTLINKFLAGS', '/SUBSYSTEM:WINDOWS')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'kernel32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'user32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'gdi32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'winspool.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'comdlg32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'advapi32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'shell32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'ole32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'oleaut32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'uuid.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'odbc32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'odbccp32.lib')
+
+			# Optimization
+			if AMBuild.options.opt == '1':
+				self.compiler.AddToListVar('CDEFINES', 'NDEBUG')
+				if self.vendor == 'gcc' or self.vendor == 'clang':
+					self.compiler.AddToListVar('CFLAGS', '-O3')
+				elif self.vendor == 'msvc':
+					self.compiler.AddToListVar('CFLAGS', '/Ox')
+					self.compiler.AddToListVar('POSTLINKFLAGS', '/OPT:ICF')
+					self.compiler.AddToListVar('POSTLINKFLAGS', '/OPT:REF')
+
+			# Debugging
+			if AMBuild.options.debug == '1':
+				self.compiler.AddToListVar('CDEFINES', 'DEBUG')
+				self.compiler.AddToListVar('CDEFINES', '_DEBUG')
+				if self.vendor == 'gcc' or self.vendor == 'clang':
+					self.compiler.AddToListVar('CFLAGS', '-g3')
+				elif self.vendor == 'msvc':
+					self.compiler.AddToListVar('CFLAGS', '/Od')
+					self.compiler.AddToListVar('CFLAGS', '/RTC1')
+
+			# Platform-specifics
+			if AMBuild.target['platform'] == 'linux':
+				self.compiler.AddToListVar('CDEFINES', '_LINUX')
+				if self.vendor == 'clang':
+					self.compiler.AddToListVar('POSTLINKFLAGS', '-lgcc_eh')
+			elif AMBuild.target['platform'] == 'darwin':
+				self.compiler.AddToListVar('CFLAGS', ['-isysroot',
+				                                      '/Developer/SDKs/MacOSX10.5.sdk'])
+				self.compiler.AddToListVar('POSTLINKFLAGS', '-mmacosx-version-min=10.5')
+				self.compiler.AddToListVar('POSTLINKFLAGS', ['-arch', 'i386'])
+				self.compiler.AddToListVar('POSTLINKFLAGS', '-lstdc++')
+			elif AMBuild.target['platform'] == 'windows':
+				self.compiler.AddToListVar('CDEFINES', 'WIN32')
+				self.compiler.AddToListVar('CDEFINES', '_WINDOWS')
+
+			# Finish up
+			self.compiler.ToConfig(AMBuild, 'compiler')
+			AMBuild.cache.CacheVariable('vendor', self.vendor)
+			self.targetMap = { }
+			AMBuild.cache.CacheVariable('targetMap', self.targetMap)
+		else:
+			self.compiler.FromConfig(AMBuild, 'compiler')
+			self.targetMap = AMBuild.cache['targetMap']
+
+		if AMBuild.target['platform'] == 'windows':
+			self.compiler.AddToListVar('RCINCLUDES', os.path.join(AMBuild.sourceFolder, 'public'))
+		try:
+			self.mmsPath = AMBuild.cache['MMSOURCE18']
+		except KeyError:
+			raise Exception('Required envvar MMSOURCE18 not defined')
+			
+		try:
+			self.smPath = AMBuild.cache['SOURCEMOD']
+		except KeyError:
+			raise Exception('Required envvar SOURCEMOD not defined')
+
+	def DefaultCompiler(self):
+		return self.compiler.Clone()
+
+	def JobMatters(self, jobname):
+		file = sys._getframe().f_code.co_filename
+		if AMBuild.mode == 'config':
+			self.targetMap[jobname] = file
+			return True
+		if len(AMBuild.args) == 0:
+			return True
+		if not jobname in AMBuild.args:
+			return False
+
+	def DefaultExtCompiler(self, path):
+		compiler = self.DefaultCompiler()
+		compiler['CXXINCLUDES'].append(os.path.join(AMBuild.sourceFolder, path, 'sdk'))
+		compiler['CXXINCLUDES'].append(os.path.join(self.smPath, 'public'))
+		compiler['CXXINCLUDES'].append(os.path.join(self.smPath, 'public', 'extensions'))
+		compiler['CXXINCLUDES'].append(os.path.join(self.smPath, 'public', 'sourcepawn'))
+		return compiler
+
+	def AutoVersion(self, folder, binary):
+		import re
+		productFile = open(os.path.join(AMBuild.sourceFolder, 'product.version'), 'r')
+		productContents = productFile.read()
+		productFile.close()
+		m = re.match('(\d+)\.(\d+)\.(\d+).*', productContents)
+		if m == None:
+			self.version = '1.0.0'
+		else:
+			major, minor, release = m.groups()
+			self.version = '{0}.{1}.{2}'.format(major, minor, release)
+		
+		if AMBuild.target['platform'] == 'windows':
+			env = {'RCDEFINES': ['BINARY_NAME="' + binary.binaryFile + '"']}
+			binary.AddResourceFile(os.path.join(folder, 'version.rc' ), env)
+		elif AMBuild.target['platform'] == 'darwin' and isinstance(binary, Cpp.LibraryBuilder):
+			binary.compiler['POSTLINKFLAGS'].extend(['-compatibility_version', '1.0.0'])
+			binary.compiler['POSTLINKFLAGS'].extend(['-current_version', self.version])
+		else:
+			return
+
+	def PreSetupHL2Job(self, job, builder, sdk):
+		info = self.sdkInfo[sdk]
+		sdkPath = AMBuild.cache[info['sdk']]
+		if AMBuild.target['platform'] == 'linux':
+			if sdk == 'ep1':
+				staticLibs = os.path.join(sdkPath, 'linux_sdk')
+			else:
+				staticLibs = os.path.join(sdkPath, 'lib', 'linux')
+			workFolder = os.path.join(AMBuild.outputFolder, job.workFolder)
+			if sdk in ['ep2v', 'l4d', 'l4d2']:
+				for i in ['tier1_i486.a', 'libvstdlib.so', 'libtier0.so']:
+					link = os.path.join(workFolder, i)
+					target = os.path.join(staticLibs, i)
+					try:
+						os.lstat(link)
+					except:
+						job.AddCommand(SymlinkCommand(link, target))
+			else:
+				for i in ['tier1_i486.a', 'vstdlib_i486.so', 'tier0_i486.so']:
+					link = os.path.join(workFolder, i)
+					target = os.path.join(staticLibs, i)
+					try:
+						os.lstat(link)
+					except:
+						job.AddCommand(SymlinkCommand(link, target))
+		elif AMBuild.target['platform'] == 'darwin':
+			staticLibs = os.path.join(sdkPath, 'lib', 'mac')
+			workFolder = os.path.join(AMBuild.outputFolder, job.workFolder)
+			for i in ['tier1_i486.a', 'libvstdlib.dylib', 'libtier0.dylib']:
+				link = os.path.join(workFolder, i)
+				target = os.path.join(staticLibs, i)
+				try:
+					os.lstat(link)
+				except:
+					job.AddCommand(SymlinkCommand(link, target))
+		elif AMBuild.target['platform'] == 'windows':
+			libs = ['tier0', 'tier1', 'vstdlib']
+			if sdk == 'swarm':
+				libs.append('interfaces')
+			for lib in libs:
+				libPath = os.path.join(sdkPath, 'lib', 'public', lib) + '.lib'
+				builder.RebuildIfNewer(libPath)
+				builder['POSTLINKFLAGS'].append(libPath)
+
+	def PostSetupHL2Job(self, job, builder, sdk):
+		if AMBuild.target['platform'] in ['linux', 'darwin']:
+			builder.AddObjectFiles(['tier1_i486.a'])
+
+	def DefaultHL2Compiler(self, path, sdk, noLink = False, oldMms = '-legacy'):
+		compiler = self.DefaultExtCompiler(path)
+
+		mms = 'core'
+		if sdk == 'ep1':
+			mms += oldMms
+
+		compiler['CXXINCLUDES'].append(os.path.join(self.mmsPath, mms))
+		compiler['CXXINCLUDES'].append(os.path.join(self.mmsPath, mms, 'sourcehook'))
+
+		info = self.sdkInfo
+		compiler['CDEFINES'].extend(['SE_' + info[i]['name'] + '=' + info[i]['def'] for i in info])
+
+		paths = [['public'], ['public', 'engine'], ['public', 'vstdlib'],
+						 ['public', 'tier0'], ['public', 'tier1']]
+		if sdk == 'ep1' or sdk == 'darkm':
+			paths.append(['public', 'dlls'])
+			paths.append(['game_shared'])
+		else:
+			paths.append(['public', 'game', 'shared'])
+			paths.append(['public', 'game', 'server'])
+
+		info = self.sdkInfo[sdk]
+		sdkPath = AMBuild.cache[info['sdk']]
+
+		compiler['CDEFINES'].append('SOURCE_ENGINE=' + info['def'])
+
+		if sdk == 'swarm' and AMBuild.target['platform'] == 'windows':
+			compiler['CDEFINES'].extend(['COMPILER_MSVC', 'COMPILER_MSVC32'])
+
+		if sdk == 'ep1':
+			if AMBuild.target['platform'] == 'linux':
+				staticLibs = os.path.join(sdkPath, 'linux_sdk')
+		else:
+			if AMBuild.target['platform'] == 'linux':
+				staticLibs = os.path.join(sdkPath, 'lib', 'linux')
+			elif AMBuild.target['platform'] == 'darwin':
+				staticLibs = os.path.join(sdkPath, 'lib', 'mac')
+
+		for i in paths:
+			compiler['CXXINCLUDES'].append(os.path.join(sdkPath, *i))
+
+		if not noLink:
+			if AMBuild.target['platform'] == 'linux':
+				compiler['POSTLINKFLAGS'][0:0] = ['-lm']
+				if sdk in ['ep2v', 'l4d', 'l4d2']:
+					compiler['POSTLINKFLAGS'][0:0] = ['libtier0.so']
+					compiler['POSTLINKFLAGS'][0:0] = ['libvstdlib.so']
+				else:
+					compiler['POSTLINKFLAGS'][0:0] = ['tier0_i486.so']
+					compiler['POSTLINKFLAGS'][0:0] = ['vstdlib_i486.so']
+			elif AMBuild.target['platform'] == 'darwin':
+				compiler['POSTLINKFLAGS'][0:0] = ['libtier0.dylib']
+				compiler['POSTLINKFLAGS'][0:0] = ['libvstdlib.dylib']
+
+		return compiler
+
+viper = Viper()
+globals = {
+	'Viper': viper
+}
+
+AMBuild.Include(os.path.join('src', 'AMBuilder'), globals)

--- a/configure.py
+++ b/configure.py
@@ -1,0 +1,9 @@
+import sys
+import ambuild.runner as runner
+
+run = runner.Runner()
+run.options.add_option('--enable-debug', action='store_const', const='1', dest='debug',
+                       help='Enable debugging symbols')
+run.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',
+                       help='Enable optimization')
+run.Configure(sys.path[0])

--- a/src/AMBuilder
+++ b/src/AMBuilder
@@ -1,13 +1,19 @@
 import os
 
 sdk = Viper.sdkInfo['ep2v']
+
 compiler = Viper.DefaultHL2Compiler('src', 'ep2v')
 compiler['CXXINCLUDES'].extend([os.path.join(AMBuild.sourceFolder, 'src', path) for path in ['', 'sdk', 'systems', 'sourcemod']])
 compiler['CXXINCLUDES'].extend([os.path.join(AMBuild.cache['PYTHONSOURCE'], path) for path in ['', 'Include']])
 compiler.AddToListVar('CXXINCLUDES', os.path.join(AMBuild.sourceFolder, 'public'))
 
 compiler.AddToListVar('CFLAGS', '-Wno-write-strings')
-compiler['POSTLINKFLAGS'].extend(['-L'+AMBuild.cache['PYTHONSOURCE'], '-lpython2.5', '-lutil'])
+compiler['POSTLINKFLAGS'].extend([
+    '-L'+AMBuild.cache['PYTHONSOURCE'], 
+    '-lpython2.5', 
+    '-lutil', 
+    '-Wl,--rpath,\$$ORIGIN/viper/lib/plat-linux2']
+    )
 
 name = 'viper.ext.' + sdk['ext']
 extension = AMBuild.AddJob(name)

--- a/src/AMBuilder
+++ b/src/AMBuilder
@@ -1,0 +1,33 @@
+import os
+
+sdk = Viper.sdkInfo['ep2v']
+compiler = Viper.DefaultHL2Compiler('src', 'ep2v')
+compiler['CXXINCLUDES'].extend([os.path.join(AMBuild.sourceFolder, 'src', path) for path in ['', 'sdk', 'systems', 'sourcemod']])
+compiler['CXXINCLUDES'].extend([os.path.join(AMBuild.cache['PYTHONSOURCE'], path) for path in ['', 'Include']])
+compiler.AddToListVar('CXXINCLUDES', os.path.join(AMBuild.sourceFolder, 'public'))
+
+compiler.AddToListVar('CFLAGS', '-Wno-write-strings')
+compiler['POSTLINKFLAGS'].extend(['-L'+AMBuild.cache['PYTHONSOURCE'], '-lpython2.5', '-lutil'])
+
+name = 'viper.ext.' + sdk['ext']
+extension = AMBuild.AddJob(name)
+binary = Cpp.LibraryBuilder(name, AMBuild, extension, compiler)
+
+Viper.PreSetupHL2Job(extension, binary, 'ep2v')
+
+binary.AddSourceFiles('src', '''
+sdk/smsdk_ext.cpp extension.cpp viper.cpp console.cpp sourcemod/sm_trie.cpp
+
+systems/ConCmdManager.cpp systems/ConVarManager.cpp systems/EventManager.cpp
+systems/PlayerManager.cpp systems/PluginSys.cpp systems/ForwardSys.cpp
+systems/HalfLife2.cpp
+
+python/py_clients.cpp python/py_events.cpp python/py_console.cpp
+python/py_forwards.cpp python/py_sourcemod.cpp python/py_entity.cpp
+python/py_halflife.cpp python/py_keyvalues.cpp python/py_datatypes.cpp
+python/py_usermessages.cpp python/py_bitbuf.cpp python/py_natives.cpp
+python/py_menus.cpp
+'''.split())
+
+Viper.PostSetupHL2Job(extension, binary, 'ep2v')
+binary.SendToJob()

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -157,16 +157,6 @@ ViperExtension::SDK_OnLoad(char *error, size_t maxlength, bool late)
     _PyExc_SystemExit = *((PyObject**)GetProcAddress(python25_DLL, "PyExc_SystemExit"));
     _PyExc_StopIteration = *((PyObject**)GetProcAddress(python25_DLL, "PyExc_StopIteration"));
     
-    g_pSendProxy_EHandleToInt = memutils->FindPattern(g_SMAPI->GetServerFactory(false),
-        "\x8B\x2A\x2A\x2A\x85\x2A\x74\x2A\x8B\x2A\x83\x2A\x2A\x74\x2A\x8B\x2A\x81\x2A"
-        "\xFF\x0F", 21);
-    
-    if (g_pSendProxy_EHandleToInt == NULL)
-    {
-        strncpy(error, "Could not find SendProxy_EHandleToInt: entity property type "
-                "autodetection would fail without it. Unloading.", maxlength);
-        return false;
-    }
 #else
     /* We must load in the binary to allow access to it.
      * Thanks to your-name-here for that bit of info!
@@ -176,6 +166,8 @@ ViperExtension::SDK_OnLoad(char *error, size_t maxlength, bool late)
         strncpy(error, "Unable to load libpython2.5.so.1.0", maxlength);
         return false;
     }
+
+#endif /* WIN32 */
 
     SourceMod::sm_sendprop_info_t propinfo;
     bool ret = gamehelpers->FindSendPropInfo("CBaseEntity", "m_hOwnerEntity", &propinfo);
@@ -192,7 +184,6 @@ ViperExtension::SDK_OnLoad(char *error, size_t maxlength, bool late)
                 "autodetection would fail without it. Unloading.", maxlength);
         return false;
     }
-#endif
     
     InitializePython();
     

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -178,7 +178,7 @@ ViperExtension::SDK_OnLoad(char *error, size_t maxlength, bool late)
     }
 
     SourceMod::sm_sendprop_info_t propinfo;
-    bool ret = gamehelpers->FindSendPropInfo("CBasePlayer", "m_hOwnerEntity", &propinfo);
+    bool ret = gamehelpers->FindSendPropInfo("CBaseEntity", "m_hOwnerEntity", &propinfo);
     if (!ret)
     {
         strncpy(error, "Could not fetch SendProp info: entity property type "

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -31,6 +31,7 @@
 #include "viper.h"
 #include "console.h"
 #include <IForwardSys.h>
+#include <dt_send.h>
 
 #if defined __linux__
 /* I wish sawce would get out of GCC, so it wouldn't be so horrible. btw, hax */
@@ -168,33 +169,23 @@ ViperExtension::SDK_OnLoad(char *error, size_t maxlength, bool late)
     }
 #else
     /* We must load in the binary to allow access to it.
-     * Thanks to your-name-here for that bit of info!
-     */
+    * Thanks to your-name-here for that bit of info!
+    */
     if (dlopen("libpython2.5.so.1.0", RTLD_NOW) == NULL)
     {
         strncpy(error, "Unable to load libpython2.5.so.1.0", maxlength);
         return false;
     }
-    
-    Dl_info info;
-    if (dladdr((void*)g_SMAPI->GetServerFactory(false), &info) == 0)
+
+    SourceMod::sm_sendprop_info_t propinfo;
+    bool ret = gamehelpers->FindSendPropInfo("CBasePlayer", "m_hOwnerEntity", &propinfo);
+    if (!ret)
     {
-        strncpy(error, "Could not find SendProxy_EHandleToInt: entity property type "
+        strncpy(error, "Could not fetch SendProp info: entity property type "
                 "autodetection would fail without it. Unloading.", maxlength);
-        return false;
     }
     
-    void *handle = dlopen(info.dli_fname, RTLD_NOW);
-    if (handle == NULL)
-    {
-        strncpy(error, "Could not find SendProxy_EHandleToInt: entity property type "
-                "autodetection would fail without it. Unloading.", maxlength);
-        return false;
-    }
-    
-    g_pSendProxy_EHandleToInt = dlsym(handle, "_Z22SendProxy_EHandleToIntPK8SendPropPKvS3_P8DVariantii");
-    dlclose(handle);
-    
+    g_pSendProxy_EHandleToInt = (void*)propinfo.prop->GetProxyFn();
     if (g_pSendProxy_EHandleToInt == NULL)
     {
         strncpy(error, "Could not find SendProxy_EHandleToInt: entity property type "

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -169,8 +169,8 @@ ViperExtension::SDK_OnLoad(char *error, size_t maxlength, bool late)
     }
 #else
     /* We must load in the binary to allow access to it.
-    * Thanks to your-name-here for that bit of info!
-    */
+     * Thanks to your-name-here for that bit of info!
+     */
     if (dlopen("libpython2.5.so.1.0", RTLD_NOW) == NULL)
     {
         strncpy(error, "Unable to load libpython2.5.so.1.0", maxlength);

--- a/src/python/py_events.cpp
+++ b/src/python/py_events.cpp
@@ -203,7 +203,7 @@ events__Event__len__(events__Event *self)
     if (self->event == NULL)
     {
         PyErr_SetString(g_pViperException, "Invalid game event.");
-        return NULL;
+        return 0;
     }
     
     self->fields = g_EventManager.GetEventFields(self->event->GetName());
@@ -211,7 +211,7 @@ events__Event__len__(events__Event *self)
     {
         PyErr_Format(g_pViperException, "UH-OH! Could not retrieve field "
             " type list for game event \"%s\".", self->event->GetName());
-        return NULL;
+        return 0;
     }
     
     return self->fields->size();
@@ -231,7 +231,7 @@ events__Event__ass_subscript__(events__Event *self, PyObject *key,
     if (self->event == NULL)
     {
         PyErr_SetString(g_pViperException, "Invalid game event.");
-        return NULL;
+        return 0;
     }
     
     if (self->fields == NULL)

--- a/src/python/py_menus.cpp
+++ b/src/python/py_menus.cpp
@@ -129,7 +129,7 @@ class ViperMenu : public IMenuHandler
 public:
     ViperMenu(PyObject *myobj, char const *title,
         IViperPluginFunction *callback)
-        : m_Callback (callback), m_TitleFunc(NULL), m_OptionsFunction(NULL),
+        : m_TitleFunc(NULL), m_Callback (callback), m_OptionsFunction(NULL),
           m_MyObject(myobj)
     {
         m_Title = sm_strdup(title);
@@ -138,7 +138,7 @@ public:
     
     ViperMenu(PyObject *myobj, IViperPluginFunction *title_func,
         IViperPluginFunction *callback)
-        : m_Callback (callback), m_TitleFunc(title_func), m_Title(NULL),
+        : m_Title(NULL), m_TitleFunc(title_func), m_Callback (callback),
           m_OptionsFunction(NULL), m_MyObject(myobj)
     {
         m_Options = new List<ViperMenuStruct>();
@@ -146,7 +146,7 @@ public:
     
     ViperMenu(PyObject *myobj, char const *title,
         IViperPluginFunction *callback, IViperPluginFunction *options)
-        : m_Callback (callback), m_Options(NULL), m_OptionsFunction(options),
+        : m_Options(NULL), m_Callback (callback), m_OptionsFunction(options),
           m_MyObject(myobj)
     {
         m_Title = sm_strdup(title);
@@ -154,8 +154,8 @@ public:
     
     ViperMenu(PyObject *myobj, IViperPluginFunction *title_func,
         IViperPluginFunction *callback, IViperPluginFunction *options)
-        : m_Callback (callback), m_TitleFunc(title_func), m_Title(NULL),
-          m_OptionsFunction(options), m_Options(NULL), m_MyObject(myobj)
+        : m_Options(NULL), m_Title(NULL), m_TitleFunc(title_func),
+          m_Callback (callback), m_OptionsFunction(options), m_MyObject(myobj)
     {
     }
     
@@ -170,7 +170,7 @@ public: // IMenuHandler
     OnMenuSelect(IBaseMenu *menu, int client, unsigned int item)
     {
         assert(m_Callback != NULL);
-        assert(PyCallable_Check(m_Callback));
+        assert(PyCallable_Check(m_Callback->GetFunction()));
         
         List<ViperMenuStruct>::iterator iter = m_Options->begin();
         unsigned int i = 0;

--- a/src/python/py_natives.cpp
+++ b/src/python/py_natives.cpp
@@ -151,7 +151,7 @@ natives__Ref__ass_item__(natives__Ref *self, Py_ssize_t n, PyObject *val)
     {
         PyErr_Format(_PyExc_IndexError, "%d is out of range, should be"
             " 0 <= n < %d", n, self->size);
-        return NULL;
+        return 0;
     }
     
     if (self->phys_addr == NULL)

--- a/src/viper_globals.h
+++ b/src/viper_globals.h
@@ -100,7 +100,7 @@ extern PyObject *g_pViperException;
     if (pPlugin == NULL) \
     { \
         PyErr_SetString(g_pViperException, "Error retrieving current plug-in"); \
-        return NULL; \
+        return 0; \
     } \
 }
 


### PR DESCRIPTION
Extension loads fine, but there are still a few things to sort out:
- Loading any modules not registered by Viper crashes the server (except built-in modules like `os` and `sys`).
- You must link libpython2.5.so.1.0 from `lib/plat-linux2` to `orangebox/bin` for the extension to load.
